### PR TITLE
Setup Verkada API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+PYTHON:=python3
+VERKADA_API_KEY:=$(VERKADA_API_KEY)
+FLAGS:=--verbose --verkada-api-key=$(VERKADA_API_KEY)
+TARGET:=src/main.py
+
+all:
+	$(PYTHON) $(TARGET) $(FLAGS)

--- a/docs/api_entry.md
+++ b/docs/api_entry.md
@@ -1,0 +1,56 @@
+## Example JSON Entry
+Response (truncated) following GET request to: https://api.verkada.com/events/v1/access
+```json
+{
+        "events":
+        [{  "device_id": "0e0cbec9-599b-48ee-b9ad-ee7504e75056",
+            "device_type": "ACCESS_CONTROL",
+            "end_timestamp": null,
+            "event_id": "138e604c-e979-4dcb-8b56-e555098bd155",
+            "event_info": {
+                "accepted": true,
+                "auxInputId": null,
+                "auxInputName": null,
+                "buildingId": "6f66d225-f748-48d1-bf21-b54a472aade6",
+                "buildingName": "SHA - Bldg 19",
+                "direction": null,
+                "doorId": "0e0cbec9-599b-48ee-b9ad-ee7504e75056",
+                "doorInfo": {
+                    "accessControllerId": "15f0c39d-f3aa-4bad-b742-c86e3275b7a6",
+                    "accessControllerName": "AC42 - SHA (by Fire Panel)",
+                    "name": "SHA - Double Doors To Gym"
+                },
+                "entityId": "0e0cbec9-599b-48ee-b9ad-ee7504e75056",
+                "entityName": "SHA - Double Doors To Gym",
+                "entityType": "door",
+                "eventType": "user_action",
+                "floorId": "6eddace7-fa59-4aee-877c-cc7ca336f90c",
+                "floorName": "FL1 - Main",
+                "floors": null,
+                "inputValue": "40|5990",
+                "lockdownInfo": null,
+                "message": "Keycard Entered",
+                "organizationId": "819624eb-0f81-4f29-9909-17de555dd64c",
+                "rawCard": "10010100000010111011001100",
+                "siteId": "a02a6b27-85e6-41d5-90e6-88611802fd92",
+                "siteName": "SHA",
+                "type": "keycard_entered_accepted",
+                "userId": "999e99bf-9999-9dd9-99e9-d9c9d99be9fc",
+                "userInfo": {
+                    "email": "johndoe@example.com",
+                    "firstName": "John",
+                    "lastName": "Doe",
+                    "name": "John Doe",
+                    "organizationId": "819624eb-0f81-4f29-9909-17de555dd64c",
+                    "phone": "999-999-9999",
+                    "userId": "999e99bf-9999-9dd9-99e9-d9c9d99be9fc"
+                },
+                "userName": "John Doe",
+                "uuid": "138e604c-e979-4dcb-8b56-e555098bd155"
+            },
+            "event_type": "DOOR_KEYCARD_ENTERED_ACCEPTED",
+            "organization_id": "819624eb-0f81-4f29-9909-17de555dd64c",
+            "site_id": "a02a6b27-85e6-41d5-90e6-88611802fd92",
+            "timestamp": "2026-01-26T22:22:34Z"
+        }]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,20 @@
+## Architecture
+Note: Arrows indicate direction of data transfer
+```mermaid
+architecture-beta
+    group wf(cloud)[Workflow]
+
+    service vk(cloud)[Verkada] in wf
+    service backend(server)[Backend] in wf
+    service db(database)[Database] in wf
+    service vz(cloud)[Metabase] in wf
+    service dashboard(internet)[Dashboard] in wf
+
+
+    %% arrows indicate
+    %% direction of data transfer
+    vk:L --> R:backend
+    db:T <-- B:backend
+    vz:L <-- R:db
+    vz:R --> L:dashboard
+```

--- a/src/Utils.py
+++ b/src/Utils.py
@@ -1,0 +1,5 @@
+import json
+
+def pretty_print_json(data):
+    pretty_json_string = json.dumps(data, indent=4, sort_keys=True)
+    print(pretty_json_string)

--- a/src/Verkada.py
+++ b/src/Verkada.py
@@ -38,10 +38,10 @@ def _get(session: requests.Session, endpoint: str) -> requests.Response:
     logging.error("Cannot continue")
     exit(1)
 
-def _get_unix_timestamp(time_delta: int=1) -> int:
+def _get_unix_timestamp(time_delta: int=1) -> str:
   yesterday = datetime.date.today() - datetime.timedelta(time_delta)
   unix_time = yesterday.strftime("%s")
-  return int(unix_time)
+  return unix_time
 
 
 def get_access_events(session: requests.Session):

--- a/src/Verkada.py
+++ b/src/Verkada.py
@@ -1,0 +1,54 @@
+import json
+import requests
+import logging
+import datetime
+
+def login(args) -> requests.Session:
+    logging.info("Logging in to Verkada")
+    session = requests.Session()
+    session.headers.update({
+        "accept": "application/json",
+        "x-api-key": args.verkada_api_key,
+    })
+    response = session.post("https://api.verkada.com/token")
+    st = response.status_code
+    if st >= 200 and st < 300:
+        all_data = json.loads(response.text)
+        session.headers.update({
+            "x-verkada-auth": all_data['token'],
+        })
+        return session
+
+    logging.error("Verkada authentication error")
+    logging.error(response.text)
+    logging.error("Cannot continue")
+    exit(1)
+
+# Generic helper for Verakada API endpoints
+def _get(session: requests.Session, endpoint: str) -> requests.Response:
+    logging.debug(f"GET Verkada API endpoint: {endpoint}")
+    response = session.get(f"https://api.verkada.com/{endpoint}")
+
+    st = response.status_code
+    if st >= 200 and st < 300:
+        return response
+
+    logging.error("Verkada API error")
+    logging.error(response.text)
+    logging.error("Cannot continue")
+    exit(1)
+
+def _get_unix_timestamp(time_delta: int=1) -> int:
+  yesterday = datetime.date.today() - datetime.timedelta(time_delta)
+  unix_time = yesterday.strftime("%s")
+  return int(unix_time)
+
+
+def get_access_events(session: requests.Session):
+    logging.info("Downloading a list of access events")
+
+    start_time = _get_unix_timestamp()
+    endpoint = f"events/v1/access?start_time={start_time}&page_size=100"
+    response = _get(session, endpoint)
+    all_data = json.loads(response.text)
+    return all_data

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,6 @@ def main():
 
     verkada_service = Verkada.login(args)
     verkada_events = Verkada.get_access_events(verkada_service)
-    print(verkada_events)
 
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,7 @@ def main():
     verkada_events = Verkada.get_access_events(verkada_service)
 
     # print the first entry in our response
+    # keeping this in for now as a sanity check
     Utils.pretty_print_json(verkada_events['events'][0])
 
 if __name__ == '__main__':

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,43 @@
+import Verkada
+import argparse
+import os
+import logging
+
+def setup_logging(args: argparse.Namespace):
+    level = logging.WARNING
+    if args.verbose:
+        level = logging.INFO
+    if args.debug:
+        level = logging.DEBUG
+
+    logging.basicConfig(level=level)
+
+def setup_cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    default_val = os.environ.get("VERKADA_API_KEY", None)
+    required_val = False if default_val else True
+
+    parser.add_argument('--verbose', action=argparse.BooleanOptionalAction)
+    parser.add_argument('--debug', action=argparse.BooleanOptionalAction)
+    parser.add_argument('--verkada-api-key',
+                        required=required_val,
+                        default=default_val,
+                        help='Verkada API key (defaults to VERKADA_API_KEY env var, if set)')
+
+    args = parser.parse_args()
+
+    setup_logging(args)
+
+    return args
+
+def main():
+    args = setup_cli()
+    logging.info(f"Initializing Verkada service")
+
+    verkada_service = Verkada.login(args)
+    verkada_events = Verkada.get_access_events(verkada_service)
+    print(verkada_events)
+
+if __name__ == '__main__':
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import Verkada
+import Utils
 import argparse
 import os
 import logging
@@ -37,6 +38,9 @@ def main():
 
     verkada_service = Verkada.login(args)
     verkada_events = Verkada.get_access_events(verkada_service)
+
+    # print the first entry in our response
+    Utils.pretty_print_json(verkada_events['events'][0])
 
 if __name__ == '__main__':
     main()

--- a/target.mk
+++ b/target.mk
@@ -1,6 +1,6 @@
 PYTHON:=python3
 VERKADA_API_KEY:=$(VERKADA_API_KEY)
-FLAGS:=--verbose --verkada-api-key=$(VERKADA_API_KEY)
+FLAGS:=--verbose
 TARGET:=src/main.py
 
 all:

--- a/target.mk
+++ b/target.mk
@@ -1,5 +1,4 @@
 PYTHON:=python3
-VERKADA_API_KEY:=$(VERKADA_API_KEY)
 FLAGS:=--verbose
 TARGET:=src/main.py
 


### PR DESCRIPTION
## Overview
This PR sets up Verkada API login so we can start working with access event data. Most of it  is copy pasta from [VerCalBot](https://github.com/VerCalBot/VerCalBot) as it already outlines how to configure the API. In `src/main.py`, `verkada_events` holds all the information pertaining to these access events (most of which we probably won't need).

## Goal For This PR
After a thorough review process, lets merge this to `develop` and I suggest further PRs should branch from `develop` as well. That way we can keep developing and debugging while keeping our `main` branch protected.

## Significant Changes
- [x] `src` directory added which contains `main.py` and `Verkada.py`
- [x]  `docs` directory added to keep track of diagrams and metadata
- [x] `target.mk` added to build the target

## Build Instructions
### Linux and MacOS
1.  Environment Variable Setup
     1. Run `exported VERKADA_API_KEY={API key provided by Estill}`
2.  Running the Target
    1.   run `make -f target.mk` in the top-level directory
### Windows
1.  Environment Variable Setup
     1. Run `set VERKADA_API_KEY={API key provided by Estill}`
2.  Running the Target
    1.   if **GNU Make** or **NMake** are not installed on your machine, you can build with the command:  
          `python3 src/main.py [--verbose] [--debug]`

    

## Requests For Reviewers
- Looking for general nitpicks i.e variable renaming, plus any ideas you guys might have after reviewing
- I left some inline comments, please feel free to respond and offer any suggestions you guys might have.

## Link to Ticket
- https://github.com/VerCalBot/VerityBot/issues/5

## Example JSON Entry
Response (truncated) following GET request to: https://api.verkada.com/events/v1/access
```json
{
            "device_id": "0e0cbec9-599b-48ee-b9ad-ee7504e75056",
            "device_type": "ACCESS_CONTROL",
            "end_timestamp": null,
            "event_id": "138e604c-e979-4dcb-8b56-e555098bd155",
            "event_info": {
                "accepted": true,
                "auxInputId": null,
                "auxInputName": null,
                "buildingId": "6f66d225-f748-48d1-bf21-b54a472aade6",
                "buildingName": "SHA - Bldg 19",
                "direction": null,
                "doorId": "0e0cbec9-599b-48ee-b9ad-ee7504e75056",
                "doorInfo": {
                    "accessControllerId": "15f0c39d-f3aa-4bad-b742-c86e3275b7a6",
                    "accessControllerName": "AC42 - SHA (by Fire Panel)",
                    "name": "SHA - Double Doors To Gym"
                },
                "entityId": "0e0cbec9-599b-48ee-b9ad-ee7504e75056",
                "entityName": "SHA - Double Doors To Gym",
                "entityType": "door",
                "eventType": "user_action",
                "floorId": "6eddace7-fa59-4aee-877c-cc7ca336f90c",
                "floorName": "FL1 - Main",
                "floors": null,
                "inputValue": "40|5990",
                "lockdownInfo": null,
                "message": "Keycard Entered",
                "organizationId": "819624eb-0f81-4f29-9909-17de555dd64c",
                "rawCard": "10010100000010111011001100",
                "siteId": "a02a6b27-85e6-41d5-90e6-88611802fd92",
                "siteName": "SHA",
                "type": "keycard_entered_accepted",
                "userId": "999e99bf-9999-9dd9-99e9-d9c9d99be9fc",
                "userInfo": {
                    "email": "johndoe@example.com",
                    "firstName": "John",
                    "lastName": "Doe",
                    "name": "John Doe",
                    "organizationId": "819624eb-0f81-4f29-9909-17de555dd64c",
                    "phone": "999-999-9999",
                    "userId": "999e99bf-9999-9dd9-99e9-d9c9d99be9fc"
                },
                "userName": "John Doe",
                "uuid": "138e604c-e979-4dcb-8b56-e555098bd155"
            },
            "event_type": "DOOR_KEYCARD_ENTERED_ACCEPTED",
            "organization_id": "819624eb-0f81-4f29-9909-17de555dd64c",
            "site_id": "a02a6b27-85e6-41d5-90e6-88611802fd92",
            "timestamp": "2026-01-26T22:22:34Z"
        }