### PR TITLE
Fix Unix timestamp handling and load environment variables via dotenv

### DIFF
--- a/src/Verkada.py
+++ b/src/Verkada.py
@@ -40,7 +40,8 @@ def _get(session: requests.Session, endpoint: str) -> requests.Response:
 
 def _get_unix_timestamp(time_delta: int=1) -> str:
   yesterday = datetime.date.today() - datetime.timedelta(time_delta)
-  unix_time = yesterday.strftime("%s")
+  yesterday_dt = datetime.datetime.combine(yesterday, datetime.time.min, tzinfo=datetime.timezone.utc)
+  unix_time = int(yesterday_dt.timestamp())
   return unix_time
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+from dotenv import load_dotenv
 import Verkada
 import Utils
 import argparse
@@ -33,6 +34,10 @@ def setup_cli() -> argparse.Namespace:
     return args
 
 def main():
+
+    # Load environment variables from the .env file (if present)
+    load_dotenv()
+
     args = setup_cli()
     logging.info(f"Initializing Verkada service")
 


### PR DESCRIPTION
# Associated Issue
- [Setup .env file for Verkada API Key](https://github.com/VerCalBot/VerityBot/issues/7)

# Summary

## - Environment Variable Handling
- Added Python ```dotenv``` to load environment variables from the local .env file.
- This will allow API keys and config values to be pulled locally without needing to commit any secrets to the repo.

##  - Unix Timestamp Compatibility 
- Replaced ```strftime("%s")``` with ```datetime.timestamp()``` to resolve platform compatibility.
- ```strftime("%s")``` is not supported by Windows; however, datetime will work across all platforms.
- Used ```datetime.combine``` to change ```yesterday``` from a date object to a datetime object.

### References
- https://docs.python.org/3/library/datetime.html
- https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/strftime-wcsftime-strftime-l-wcsftime-l?view=msvc-170&redirectedfrom=MSDN
- https://pypi.org/project/python-dotenv/

