### PR TITLE
Read Config .ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Configs .ini
+config.ini
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,2 @@
+[Email]
+email_to = 1234@example.com

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+from configparser import ConfigParser
 import Verkada
 import Utils
 import argparse
@@ -37,6 +38,12 @@ def main():
 
     # Load environment variables from the .env file (if present)
     load_dotenv()
+
+    # Load config.ini file
+    config = ConfigParser()
+    config.read("../config.ini")
+
+    print(config["Email"]["email_to"])
 
     args = setup_cli()
     logging.info(f"Initializing Verkada service")


### PR DESCRIPTION
Using configparser in main now allows for a .ini file to be used for configuration.

**Changes**
- Added the ability to read an email address from the config.ini file to be used with dashboard  distribution
- Added config.ini.example to help users with setup
- Added a print statement in main to confirm the .ini file is being read correctly

**Test**
1. Create a copy of config.ini.example in the same directory named config.ini
2. Run main.py and you should see the example email printed above the Verkada data.

