### PR TITLE
Fix ETL exit code 2 caused by missing output-log flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ EXPOSE 8080
 RUN useradd app
 USER app
 
-CMD ["python", "src/main.py"]
+CMD ["python", "src/main.py", "--output-log", "/tmp/app.log"]


### PR DESCRIPTION
Added the required --output-log flag to the ETL Dockerfile; logs are written to /tmp inside the container.  After pulling changes, please rebuild the ETL image so the new configurations are applied to the ETL_json container. 