### PR TITLE
Added a function to convert dict to ndjson and removed the local output log flag requirement

### DIFF
--- a/src/Application.py
+++ b/src/Application.py
@@ -19,4 +19,8 @@ def init():
         if not verkada.EOR_page():
             # right now, verkada's current pipeline is doing nothing
             verkada.pipe()
-            Utils.pretty_print_json(current_page['events'][0])
+            print(verkada.current_page_ndjson())
+
+            # To format in regular JSON instead of NDJSON, uncomment the line below and comment out the print statement above
+            #Utils.pretty_print_json(current_page['events'][0])
+

--- a/src/CLI.py
+++ b/src/CLI.py
@@ -29,7 +29,7 @@ def setup_cli() -> argparse.Namespace:
                         default=default_val,
                         help='Verkada API key (defaults to VERKADA_API_KEY env var, if set)')
     parser.add_argument('--output-log',
-                        required=True,
+                        required=False,
                         default=None,
                         help='Output log file for the current build')
 

--- a/src/Verkada.py
+++ b/src/Verkada.py
@@ -78,8 +78,14 @@ class VerkadaContext:
 
         self._current_page = self._get(endpoint).json()
         self._next_page_token = self._current_page['next_page_token']
-
+        
         return self._current_page
+    
+
+    def current_page_ndjson(self) -> str:
+        return "\n".join(
+            json.dumps(e) for e in self._current_page.get("events", [])
+        )
 
     # checks if we've reached the end-of-request page
     def EOR_page(self) -> bool:


### PR DESCRIPTION
- Added the function "current_page_ndjson" to Verkada.py to convert the current page of access events from a dict to an ndjson string as well as printing functionality in Application.py. 
- Left the original JSON print statement for testing as NDJSON is inherently difficult to read in the terminal

- Removed the requirement for the output log flag in CLI.py to allow for local testing (outside of Docker) without logging.