### PR TITLE
Added Email.py to send customizable email using .ini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ VERKADA_API_KEY=This should be your API Key==
 ELASTIC_PASSWORD=At least six characters long
 KIBANA_SYSTEM_PASSWORD=At least six characters long and you will need to set in Kibana refer to README
 KIBANA_ENCRYPTION_KEY=Create Key using command "openssl rand -base64 32" in linux or wsl==
+EMAIL_PASSWORD = Password for the email account you are sending the dashboard from

--- a/config.ini.example
+++ b/config.ini.example
@@ -3,3 +3,4 @@ EMAIL_TO = receiver_email@example.com
 EMAIL_FROM = your_email@example.com
 EMAIL_SUBJECT = Subject for the Email 
 EMAIL_MESSAGE = The message you would like to send along with the dashboard link
+EMAIL_SEND_TIME = 07:00pm

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,4 +1,5 @@
 [Email]
 EMAIL_TO = receiver_email@example.com
-EMAIL_FROM = your_email@example.com 
+EMAIL_FROM = your_email@example.com
+EMAIL_SUBJECT = Subject for the Email 
 EMAIL_MESSAGE = The message you would like to send along with the dashboard link

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,2 +1,4 @@
 [Email]
-email_to = 1234@example.com
+EMAIL_TO = receiver_email@example.com
+EMAIL_FROM = your_email@example.com 
+EMAIL_MESSAGE = The message you would like to send along with the dashboard link

--- a/src/email.py
+++ b/src/email.py
@@ -14,7 +14,6 @@ sender_email = config ['Email'] ['EMAIL_FROM']
 email_subject = config ['Email'] ['EMAIL_SUBJECT']
 email_message = config ['Email'] ['EMAIL_MESSAGE']
 
-
 message = MIMEMultipart()
 message["From"] = sender_email
 message["To"] = recipient_email
@@ -28,6 +27,7 @@ email_password = os.getenv("EMAIL_PASSWORD")
 
 # creates SMTP session
 s = smtplib.SMTP('smtp.gmail.com',587)
+
 
 s.set_debuglevel(1)
 

--- a/src/email.py
+++ b/src/email.py
@@ -8,7 +8,6 @@ from email.mime.text import MIMEText
 config = configparser.ConfigParser()
 config.read("../config.ini")
 
-# Assign variables from ini
 recipient_email = config ['Email'] ['EMAIL_TO']
 sender_email = config ['Email'] ['EMAIL_FROM']
 email_subject = config ['Email'] ['EMAIL_SUBJECT']
@@ -22,12 +21,9 @@ body = email_message
 message.attach(MIMEText(body, "plain"))
 
 load_dotenv()
-# Retrieve password from env
 email_password = os.getenv("EMAIL_PASSWORD")
 
-# creates SMTP session
 s = smtplib.SMTP('smtp.gmail.com',587)
-
 
 s.set_debuglevel(1)
 
@@ -38,3 +34,4 @@ s.login(sender_email, email_password)
 s.sendmail(sender_email,recipient_email,message.as_string())
 
 s.quit()
+

--- a/src/email.py
+++ b/src/email.py
@@ -2,6 +2,8 @@ import os
 import smtplib
 import configparser
 from dotenv import load_dotenv
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 
 config = configparser.ConfigParser()
 config.read("../config.ini")
@@ -9,7 +11,16 @@ config.read("../config.ini")
 # Assign variables from ini
 recipient_email = config ['Email'] ['EMAIL_TO']
 sender_email = config ['Email'] ['EMAIL_FROM']
-message = config ['Email'] ['EMAIL_MESSAGE']
+email_subject = config ['Email'] ['EMAIL_SUBJECT']
+email_message = config ['Email'] ['EMAIL_MESSAGE']
+
+
+message = MIMEMultipart()
+message["From"] = sender_email
+message["To"] = recipient_email
+message["Subject"] = email_subject
+body = email_message
+message.attach(MIMEText(body, "plain"))
 
 load_dotenv()
 # Retrieve password from env
@@ -24,6 +35,6 @@ s.starttls()
 
 s.login(sender_email, email_password)
 
-s.sendmail(sender_email,recipient_email,message)
+s.sendmail(sender_email,recipient_email,message.as_string())
 
 s.quit()

--- a/src/email.py
+++ b/src/email.py
@@ -1,23 +1,24 @@
 import os
 import smtplib
 import configparser
-# from dotenv import load_dotenv
-#Remove docker got it
-# load_dotenv()
+from dotenv import load_dotenv
 
 config = configparser.ConfigParser()
 config.read("../config.ini")
 
-#Assign variables from ini
+# Assign variables from ini
 recipient_email = config ['Email'] ['EMAIL_TO']
 sender_email = config ['Email'] ['EMAIL_FROM']
 message = config ['Email'] ['EMAIL_MESSAGE']
 
-#Assign variable from env
+load_dotenv()
+# Retrieve password from env
 email_password = os.getenv("EMAIL_PASSWORD")
 
 # creates SMTP session
-s = smtplib.SMTP('smtp.office365.com',587)
+s = smtplib.SMTP('smtp.gmail.com',587)
+
+s.set_debuglevel(1)
 
 s.starttls()
 

--- a/src/email.py
+++ b/src/email.py
@@ -1,0 +1,14 @@
+import smtplib
+
+# creates SMTP session
+s = smtplib.SMTP('smtp.office365.com',587)
+
+s.starttls()
+
+s.login("sender_email","sender_pass")
+
+content = "link_to_Kibana"
+
+s.sendmail("sender_email","receiver_email",content)
+
+s.quit()

--- a/src/email.py
+++ b/src/email.py
@@ -1,14 +1,28 @@
+import os
 import smtplib
+import configparser
+# from dotenv import load_dotenv
+#Remove docker got it
+# load_dotenv()
+
+config = configparser.ConfigParser()
+config.read("../config.ini")
+
+#Assign variables from ini
+recipient_email = config ['Email'] ['EMAIL_TO']
+sender_email = config ['Email'] ['EMAIL_FROM']
+message = config ['Email'] ['EMAIL_MESSAGE']
+
+#Assign variable from env
+email_password = os.getenv("EMAIL_PASSWORD")
 
 # creates SMTP session
 s = smtplib.SMTP('smtp.office365.com',587)
 
 s.starttls()
 
-s.login("sender_email","sender_pass")
+s.login(sender_email, email_password)
 
-content = "link_to_Kibana"
-
-s.sendmail("sender_email","receiver_email",content)
+s.sendmail(sender_email,recipient_email,message)
 
 s.quit()

--- a/src/mailer.py
+++ b/src/mailer.py
@@ -1,6 +1,9 @@
 import os
 import smtplib
 import configparser
+import schedule
+import time
+import re
 from dotenv import load_dotenv
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -23,15 +26,29 @@ message.attach(MIMEText(body, "plain"))
 load_dotenv()
 email_password = os.getenv("EMAIL_PASSWORD")
 
-s = smtplib.SMTP('smtp.gmail.com',587)
+def send_email():
+    s = smtplib.SMTP('smtp.gmail.com',587)
+    s.set_debuglevel(1)
+    s.starttls()
+    s.login(sender_email, email_password)
+    s.sendmail(sender_email,recipient_email,message.as_string())
+    s.quit()
 
-s.set_debuglevel(1)
+mail_time = config ['Email'] ['EMAIL_SEND_TIME']
+h, m, am_pm = re.findall(r'\d+|\w+', mail_time)
+hour = int(h)
+mins = int(m)
+if am_pm.lower() == 'pm' and hour != 12:
+    hour += 12
+elif am_pm.lower() == 'am' and hour == 12:
+    hour = 0
 
-s.starttls()
+mail_time = f'{hour:02d}:{mins:02d}'
+print(mail_time)
 
-s.login(sender_email, email_password)
 
-s.sendmail(sender_email,recipient_email,message.as_string())
+schedule.every().day.at("07:24").do(send_email)
 
-s.quit()
-
+while True:
+    schedule.run_pending()
+    time.sleep(60)


### PR DESCRIPTION
Using SMTP this allows an email message to be sent that the user can customize using the .ini to set the to, from, subject, and email message.

I still had to use load_dotenv to get this working successfully even with Docker.

Once I have a test outlook account to try this on I plan to add a section where the time can be set so the user can customize when the email will be sent.