### PR TITLE
Reworked setup scripts and added nginx

### DIFF
--- a/scripts/elastic_setup.sh
+++ b/scripts/elastic_setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Run this from the root of the repo
+
+# terminate the script immediately if error occurs
+set -e
+
+# Move into repo root
+cd "$(dirname "$0")/.."
+
+INITIAL_COMPOSE="compose.initial.yaml"
+ES_CONTAINER="elasticsearch"
+ES_URL="http://localhost:9200"
+
+# Will print the first argument given after using the function fail.  Ex: ERROR: This will be a string appearing after fail.
+fail() {
+    echo
+    echo "ERROR: $1"
+    exit 1
+}
+
+echo "Make sure your .env file already contains the kibana_system password before continuing."
+echo "Starting initial stack..."
+# -f allows for user to use a specific compose file such as compose.initial instead of the default compose.yaml
+docker compose -f "${INITIAL_COMPOSE}" up -d
+
+echo
+echo "Waiting for Elasticsearch to start..."
+
+# Iterate i through range of 1 to 60
+for i in {1..60}; do
+    # if container reponse succeeds then container is ready
+    if docker exec "${ES_CONTAINER}" curl -s "${ES_URL}" >/dev/null; then
+        echo "Elasticsearch is ready."
+        break
+    fi
+
+    echo "Still waiting... (${i}/60)"
+    sleep 5
+
+    # if i equals 60 then fail
+    if [ "$i" -eq 60 ]; then
+        fail "Elasticsearch did not start in time.
+Check logs with: docker compose -f ${INITIAL_COMPOSE} logs elasticsearch"
+    fi
+done
+
+echo
+echo "Resetting kibana_system password..."
+echo "When prompted, enter the password you already placed in your .env file."
+
+# -it ensures user can enter password into terminal
+docker exec -it "${ES_CONTAINER}" \
+    bin/elasticsearch-reset-password \
+    -u kibana_system \
+    -i \
+    --url "${ES_URL}"
+
+echo
+echo "Stopping initial stack..."
+docker compose -f "${INITIAL_COMPOSE}" down

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -7,70 +7,22 @@ set -e
 # Move into repo root
 cd "$(dirname "$0")/.."
 
-INITIAL_COMPOSE="compose.initial.yaml"
-ES_CONTAINER="elasticsearch"
-ES_URL="http://localhost:9200"
-
-# Will print the first argument given after using the function fail.  Ex: ERROR: This will be a string appearing after fail.
-fail() {
-    echo
-    echo "ERROR: $1"
-    exit 1
-}
-
-echo "Checking dependencies..."
-
-# Checks if unzip is installed
-if ! command -v unzip &> /dev/null; then
-    echo "Error: unzip is required but not installed."
-    echo "Please install unzip and rerun this script."
-    exit 1
-fi
-
-echo "Make sure your .env file already contains the kibana_system password before continuing."
-echo "Starting initial stack..."
-# -f allows for user to use a specific compose file such as compose.initial instead of the default compose.yaml
-docker compose -f "${INITIAL_COMPOSE}" up -d
 
 echo
-echo "Waiting for Elasticsearch to start..."
-
-# Iterate i through range of 1 to 60
-for i in {1..60}; do
-    # if container reponse succeeds then container is ready
-    if docker exec "${ES_CONTAINER}" curl -s "${ES_URL}" >/dev/null; then
-        echo "Elasticsearch is ready."
-        break
-    fi
-
-    echo "Still waiting... (${i}/60)"
-    sleep 5
-
-    # if i equals 60 then fail
-    if [ "$i" -eq 60 ]; then
-        fail "Elasticsearch did not start in time.
-Check logs with: docker compose -f ${INITIAL_COMPOSE} logs elasticsearch"
-    fi
-done
+echo "Running dependencies script..."
+./scripts/install_dependencies.sh
 
 echo
-echo "Resetting kibana_system password..."
-echo "When prompted, enter the password you already placed in your .env file."
-
-# -it ensures user can enter password into terminal
-docker exec -it "${ES_CONTAINER}" \
-    bin/elasticsearch-reset-password \
-    -u kibana_system \
-    -i \
-    --url "${ES_URL}"
+echo "running elastic_setup.sh..."
+./scripts/elastic_setup.sh
 
 echo
-echo "Stopping initial stack..."
-docker compose -f "${INITIAL_COMPOSE}" down
-
-echo
-echo "Running certificate creation script..."
+echo "Running certificate creation script for ElasticSearch..."
 ./scripts/cert_creation.sh
+
+echo
+echo "Running nginx setup..."
+./scripts/nginx_setup.sh
 
 echo
 echo "Starting normal secure stack..."

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -18,6 +18,14 @@ fail() {
     exit 1
 }
 
+echo "Checking dependencies..."
+
+# Checks if unzip is installed
+if ! command -v unzip &> /dev/null; then
+    echo "Error: unzip is required but not installed."
+    echo "Please install unzip and rerun this script."
+    exit 1
+fi
 
 echo "Make sure your .env file already contains the kibana_system password before continuing."
 echo "Starting initial stack..."

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run this from the root of the repo
+
+# terminate the script immediately if error occurs
+set -e
+
+echo "Checking dependencies..."
+sudo apt update
+
+# Checks if unzip is installed
+if ! command -v unzip &> /dev/null; then
+    echo "Installing unzip..."
+    sudo apt install -y unzip
+fi
+
+# Checks if nginx is installed
+if ! command -v nginx &> /dev/null; then
+    echo "Installing nginx..."
+    sudo apt install -y nginx
+fi
+
+# Checks if nginx is installed
+if ! command -v openssl &> /dev/null; then
+    echo "Installing openssl..."
+    sudo apt install -y openssl
+fi
+
+echo "Dependencies check complete"

--- a/scripts/nginx_setup.sh
+++ b/scripts/nginx_setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Run this from the root of the repo
+
+# terminate the script immediately if error occurs
+set -e
+
+echo
+echo "Creating nginx config file"
+
+sudo tee /etc/nginx/nginx.conf > /dev/null <<'EOF'
+events {}
+
+http {
+    # VerityBot server
+    server {
+        listen 80;
+        server_name _;
+
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate /etc/nginx/ssl/nginx.crt;
+        ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        location / {
+            proxy_pass https://localhost:5601;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_ssl_verify off;
+        }
+    }
+}
+EOF
+
+echo
+echo "Creating certs for reverse proxy setup..."
+
+sudo mkdir -p /etc/nginx/ssl
+
+sudo openssl req -x509 -nodes -days 365 \
+-newkey rsa:2048 \
+-keyout /etc/nginx/ssl/nginx.key \
+-out /etc/nginx/ssl/nginx.crt \
+-subj "/CN=localhost"
+
+sudo nginx -t
+sudo systemctl restart nginx


### PR DESCRIPTION
During initial setup on a new device running WSL,  Initial_setup.sh errored out after trying to unzip ca.zip using cert_creation.sh. This was because the unzip dependency was not installed by default in WSL, which it normally is for Git Bash.  Instead of trying to automate the installation of the dependency across multiple platforms, I believe exiting with exit 1 and informing the user to install the dependency is the most practical and efficient method.  