### PR TITLE
Add exit logic to ETL to ensure container stops after completion

### DIFF
--- a/src/Application.py
+++ b/src/Application.py
@@ -49,6 +49,11 @@ def init():
             # Logs when we reached last page
             if verkada.is_eor_page():
                 logging.info("Finished all pages")
+                break
+
+        logging.info("ETL job completed. Exiting container")
+        exit(0)
 
     else:
         logging.error("ElasticSearch connection timed out")
+        exit(1)


### PR DESCRIPTION
I think this should resolve our ETL service not closing after running sometimes. I looked into changing our cron creation command to do a force recreate for our ETL service; however, this will make it recreate immediately, which could interrupt a longer pull of data, which wouldnt break anything since on the next update, it would continue where it left off; however would not be ideal.